### PR TITLE
Fix config file write on linux and mac

### DIFF
--- a/bcu_yaml.c
+++ b/bcu_yaml.c
@@ -68,7 +68,11 @@ struct bcu_yaml_version ver_before_big_ver[] =
 void get_yaml_file_path(char* path)
 {
 #if defined(linux) || defined(__APPLE__)
-	strcat(path, getenv("HOME"));
+	char * tmpenv;
+	if (( tmpenv = getenv( "HOME" )) != NULL )
+		strcat(path, tmpenv);
+	else
+		printf("HOME env variable not set.\n");
 	strcat(path, "/bcu_config.yaml");
 #else
 	const char* homeProfile = "USERPROFILE";


### PR DESCRIPTION
When trying to run bcu from a script or in an environment where $HOME is not set it will segfault attempting to read environment variable. This patch fixes the issue. As a side effect the config will be written to /bcu_config.yaml which might not be available to the user. In such circumstances bcu will exit gracefully instead of segfaulting.