### PR TITLE
Fix create_version_h.sh for out of tree builds

### DIFF
--- a/create_version_h.sh
+++ b/create_version_h.sh
@@ -4,8 +4,8 @@ if [ "${APPVEYOR_BUILD_VERSION}" = "" ];
 then
 	echo build not in appveyor
 else
-	git tag ${APPVEYOR_BUILD_VERSION}
+    (cd "${1}"; git tag ${APPVEYOR_BUILD_VERSION})
 fi
 
-version=`git describe --tags --long`
+version=$(cd "${1}"; git describe --tags --long)
 echo "#define GIT_VERSION \"$version\"" > ${1}/version.h


### PR DESCRIPTION
When building out of tree generated version.sh contains empty version. This patch fixes the issue by using subshell to change directory to the git tree from which cmake takes the sources. The fix only applies to building BCU on Posix compliant systems.